### PR TITLE
Tab to switch pane

### DIFF
--- a/src/Camelot.ViewModels/Implementations/MainWindowViewModel.cs
+++ b/src/Camelot.ViewModels/Implementations/MainWindowViewModel.cs
@@ -39,6 +39,8 @@ namespace Camelot.ViewModels.Implementations
 
         public ICommand SearchCommand { get; }
 
+        public ICommand SwitchPanelCommand { get; }
+
         public MainWindowViewModel(
             IFilesOperationsMediator filesOperationsMediator,
             IOperationsViewModel operationsViewModel,
@@ -64,6 +66,7 @@ namespace Camelot.ViewModels.Implementations
             CreateNewTabCommand = ReactiveCommand.Create(CreateNewTab);
             CloseCurrentTabCommand = ReactiveCommand.Create(CloseActiveTab);
             SearchCommand = ReactiveCommand.Create(Search);
+            SwitchPanelCommand = ReactiveCommand.Create(SwitchPanel);
 
             filesOperationsMediator.Register(leftFilesPanelViewModel, rightFilesPanelViewModel);
         }
@@ -73,5 +76,7 @@ namespace Camelot.ViewModels.Implementations
         private void CloseActiveTab() => ActiveTabsListViewModel.CloseActiveTab();
 
         private void Search() => _filesOperationsMediator.ToggleSearchPanelVisibility();
+
+        private void SwitchPanel() => _filesOperationsMediator.InactiveFilesPanelViewModel.Activate();
     }
 }

--- a/src/Camelot/Views/MainWindow.xaml
+++ b/src/Camelot/Views/MainWindow.xaml
@@ -20,6 +20,7 @@
         <KeyBinding Gesture="Meta+W" Command="{Binding CloseCurrentTabCommand}" />
         <KeyBinding Gesture="Ctrl+F" Command="{Binding SearchCommand}" />
         <KeyBinding Gesture="Meta+F" Command="{Binding SearchCommand}" />
+        <KeyBinding Gesture="Tab" Command="{Binding SwitchPanelCommand}" />
     </Window.KeyBindings>
 
     <Design.DataContext>


### PR DESCRIPTION
I'm always on the lookout for a good filemanager. Congrats on a good start :-)

The first thing I noticed when testing it out, was the lack of possibility to switch between left- and rightside file panels using TAB-key. I've made a small attempt at implementing such a feature, but even though it do move the focus between the file panels, the file list doesn't receive focus so it's still isn't possible to put away the mouse..

Loosing input focus on the file lists seems to be a weakness. If it's not possible to keep the list focused, there should be a quick way of focusing the list. Maybe arrow up and arrow down, since that's the way you'll most likely discover that you don't have focus.. 