### PR TITLE
Bugfix/shell icons path extension

### DIFF
--- a/src/Camelot.Services.Abstractions/IPathService.cs
+++ b/src/Camelot.Services.Abstractions/IPathService.cs
@@ -18,8 +18,6 @@ public interface IPathService
 
     string GetExtension(string path);
 
-    bool IsExtension(string extension);
-
     string RightTrimPathSeparators(string path);
 
     string LeftTrimPathSeparators(string relativePath);

--- a/src/Camelot.Services.Abstractions/IPathService.cs
+++ b/src/Camelot.Services.Abstractions/IPathService.cs
@@ -18,6 +18,8 @@ public interface IPathService
 
     string GetExtension(string path);
 
+    bool IsExtension(string extension);
+
     string RightTrimPathSeparators(string path);
 
     string LeftTrimPathSeparators(string relativePath);

--- a/src/Camelot.Services.Environment/Implementations/EnvironmentPathService.cs
+++ b/src/Camelot.Services.Environment/Implementations/EnvironmentPathService.cs
@@ -16,4 +16,6 @@ public class EnvironmentPathService : IEnvironmentPathService
     public string GetFileName(string path) => Path.GetFileName(path);
 
     public string GetExtension(string path) => Path.GetExtension(path);
+
+    public char GetDirectorySeparator() => Path.DirectorySeparatorChar;
 }

--- a/src/Camelot.Services.Environment/Interfaces/IEnvironmentPathService.cs
+++ b/src/Camelot.Services.Environment/Interfaces/IEnvironmentPathService.cs
@@ -13,4 +13,6 @@ public interface IEnvironmentPathService
     string GetFileName(string path);
 
     string GetExtension(string path);
+
+    char GetDirectorySeparator();
 }

--- a/src/Camelot.Services/PathService.cs
+++ b/src/Camelot.Services/PathService.cs
@@ -88,17 +88,6 @@ public class PathService : IPathService
         return extension.StartsWith(".") ? extension[1..] : extension;
     }
 
-    public bool IsExtension(string extension)
-    {
-        if (string.IsNullOrWhiteSpace(extension))
-            return false;
-        if (extension.Contains("."))
-            return false;
-        if (extension.Contains(_environmentPathService.GetDirectorySeparator()))
-            return false;
-        return true;
-    }
-
     public string RightTrimPathSeparators(string path) => path == "/" ? path : path.TrimEnd('/').TrimEnd('\\');
 
     public string LeftTrimPathSeparators(string relativePath) => relativePath.TrimStart('/').TrimStart('\\');

--- a/src/Camelot.Services/PathService.cs
+++ b/src/Camelot.Services/PathService.cs
@@ -63,6 +63,12 @@ public class PathService : IPathService
         return string.IsNullOrEmpty(fileName) ? path : fileName;
     }
 
+    /// <summary>
+    /// Returns the extension of the given path, without the prefix of dot.
+    /// This is intentionally returns different result than <see cref="System.IO.Path.GetExtension"/
+    /// </summary>
+    /// <param name="path"></param>
+    /// <returns></returns>
     public string GetExtension(string path)
     {
         if (path.StartsWith("."))
@@ -80,6 +86,17 @@ public class PathService : IPathService
         var extension = _environmentPathService.GetExtension(path);
 
         return extension.StartsWith(".") ? extension[1..] : extension;
+    }
+
+    public bool IsExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            return false;
+        if (extension.Contains("."))
+            return false;
+        if (extension.Contains(_environmentPathService.GetDirectorySeparator()))
+            return false;
+        return true;
     }
 
     public string RightTrimPathSeparators(string path) => path == "/" ? path : path.TrimEnd('/').TrimEnd('\\');

--- a/src/Camelot.ViewModels.Windows/ShellIcons/WindowsIconTypes.cs
+++ b/src/Camelot.ViewModels.Windows/ShellIcons/WindowsIconTypes.cs
@@ -12,11 +12,6 @@
             {
                 throw new ArgumentNullException(nameof(extension));
             }
-            if (extension.StartsWith("."))
-            {
-                // As per stanards of this project, extension don't have dot prefix.
-                throw new ArgumentOutOfRangeException(nameof(extension));
-            }
             if (fileName.Contains('?') || fileName.Contains(','))
             {
                 return true; // icon in indexed resource

--- a/src/Camelot.ViewModels.Windows/ShellIcons/WindowsIconTypes.cs
+++ b/src/Camelot.ViewModels.Windows/ShellIcons/WindowsIconTypes.cs
@@ -8,13 +8,20 @@
             {
                 throw new ArgumentNullException(nameof(fileName));
             }
-
+            if (string.IsNullOrEmpty(extension)) 
+            {
+                throw new ArgumentNullException(nameof(extension));
+            }
+            if (extension.StartsWith("."))
+            {
+                // As per stanards of this project, extension don't have dot prefix.
+                throw new ArgumentOutOfRangeException(nameof(extension));
+            }
             if (fileName.Contains('?') || fileName.Contains(','))
             {
                 return true; // icon in indexed resource
             }
-
-            var extensionsOfIcoFiles = new List<string> { ".ico", ".exe", ".dll" , ".cpl", ".appref-ms", ".msc" };
+            var extensionsOfIcoFiles = new List<string> { "ico", "exe", "dll" , "cpl", "appref-ms", "msc" };
 
             return extensionsOfIcoFiles.Contains(extension);
         }

--- a/src/Camelot.ViewModels.Windows/ShellIcons/WindowsShellIconsService.cs
+++ b/src/Camelot.ViewModels.Windows/ShellIcons/WindowsShellIconsService.cs
@@ -23,7 +23,7 @@ public class WindowsShellIconsService : IShellIconsService
 
     public ImageModel GetIconForExtension(string extension)
     {
-        if (!_pathService.IsExtension(extension))
+        if (string.IsNullOrEmpty(extension))
         {
             throw new ArgumentException(extension, nameof(extension));
         }

--- a/src/Camelot.ViewModels.Windows/ShellIcons/WindowsShellIconsService.cs
+++ b/src/Camelot.ViewModels.Windows/ShellIcons/WindowsShellIconsService.cs
@@ -23,19 +23,14 @@ public class WindowsShellIconsService : IShellIconsService
 
     public ImageModel GetIconForExtension(string extension)
     {
-        if (string.IsNullOrEmpty(extension))
+        if (!_pathService.IsExtension(extension))
         {
-            throw new ArgumentNullException(nameof(extension));
+            throw new ArgumentException(extension, nameof(extension));
         }
 
-        if (!extension.StartsWith("."))
+        if (extension.ToLower() == "lnk")
         {
-            throw new ArgumentException(nameof(extension));
-        }
-
-        if (extension.ToLower() == ".lnk")
-        {
-            throw new ArgumentException("Need to resolve .lnk first");
+            throw new ArgumentException("Need to resolve 'lnk' first");
         }
 
         var iconFilename = ShellIcon.GetIconForExtension(extension);
@@ -65,11 +60,10 @@ public class WindowsShellIconsService : IShellIconsService
         {
             throw new ArgumentOutOfRangeException(nameof(path));
         }
-
-        var ext = GetExtension(path);
-        if (ext == ".lnk")
+        var ext = GetExtensionAsLowerCase(path);
+        if (ext == "lnk")
         {
-            throw new ArgumentException("Need to resolve .lnk first");
+            throw new ArgumentException("Need to resolve 'lnk' first");
         }
 
         return LoadIcon(path);
@@ -84,7 +78,7 @@ public class WindowsShellIconsService : IShellIconsService
 
         ImageModel result;
 
-        var needsExtract = WindowsIconTypes.IsIconThatRequiresExtract(path, GetExtension(path));
+        var needsExtract = WindowsIconTypes.IsIconThatRequiresExtract(path, GetExtensionAsLowerCase(path));
         if (needsExtract)
         {
             var icon = IconExtractor.ExtractIcon(path);
@@ -118,18 +112,18 @@ public class WindowsShellIconsService : IShellIconsService
             throw new ArgumentNullException(nameof(filename));
         }
 
-        var ext = GetExtension(filename);
-
-        // next extensions require that the icon will be resolved by full path,
+        var ext = GetExtensionAsLowerCase(filename);
+        // Next extensions require that the icon will be resolved by full path,
         // and not just the extension itself.
-        var extensionForFullPaths = new[] { ".exe", ".cpl", ".appref-ms", ".msc" };
+        // As per stanards of this project, extension don't have dot prefix.
+        var extensionForFullPaths = new[] { "exe", "cpl", "appref-ms", "msc" };
 
         return extensionForFullPaths.Contains(ext)
             ? ShellIconType.FullPath
             : ShellIconType.Extension;
     }
 
-    private string GetExtension(string filename)
+    private string GetExtensionAsLowerCase(string filename)
     {
         return _pathService.GetExtension(filename).ToLower();
     }

--- a/src/Camelot.ViewModels.Windows/ShellIcons/WindowsShellLinksService.cs
+++ b/src/Camelot.ViewModels.Windows/ShellIcons/WindowsShellLinksService.cs
@@ -25,8 +25,7 @@ public class WindowsShellLinksService : IShellLinksService
         }
 
         var ext = _pathService.GetExtension(path).ToLower();
-
-        return ext == ".lnk";
+        return ext == "lnk";
     }
 
     public string ResolveLink(string path)

--- a/src/Camelot.ViewModels.Windows/WinApi/ShellIcon.cs
+++ b/src/Camelot.ViewModels.Windows/WinApi/ShellIcon.cs
@@ -11,10 +11,14 @@ public static class ShellIcon
             throw new ArgumentNullException(nameof(extension));
         }
 
-        if (!extension.StartsWith("."))
+        if (extension.StartsWith("."))
         {
-            throw new ArgumentException(nameof(extension));
+            // As per stanards of this project, extension don't have dot prefix.
+            throw new ArgumentOutOfRangeException(nameof(extension));
         }
+
+        // But to work with Windows API, we still need to add dot prefix...
+        extension = "." + extension;
 
         const Win32.AssocF assocFlag = Win32.AssocF.None;
         var currentAppIcon = Win32.AssocQueryString(assocFlag, Win32.AssocStr.AppIconRreference, extension);

--- a/src/Camelot.ViewModels.Windows/WinApi/ShellIcon.cs
+++ b/src/Camelot.ViewModels.Windows/WinApi/ShellIcon.cs
@@ -12,12 +12,6 @@ public static class ShellIcon
             throw new ArgumentNullException(nameof(extension));
         }
 
-        if (extension.StartsWith("."))
-        {
-            // As per stanards of this project, extension don't have dot prefix.
-            throw new ArgumentOutOfRangeException(nameof(extension));
-        }
-
         // But to work with Windows API, we still need to add dot prefix...
         extension = "." + extension;
 

--- a/src/Camelot.ViewModels.Windows/WinApi/ShellIcon.cs
+++ b/src/Camelot.ViewModels.Windows/WinApi/ShellIcon.cs
@@ -1,4 +1,5 @@
 ﻿using Camelot.Services.Windows.WinApi;
+using System.Diagnostics;
 
 namespace Camelot.ViewModels.Windows.WinApi;
 
@@ -23,9 +24,29 @@ public static class ShellIcon
         const Win32.AssocF assocFlag = Win32.AssocF.None;
         var currentAppIcon = Win32.AssocQueryString(assocFlag, Win32.AssocStr.AppIconRreference, extension);
 
-        return string.IsNullOrEmpty(currentAppIcon)
-            ? Win32.AssocQueryString(assocFlag, Win32.AssocStr.DefaultIcon, extension)
-            : currentAppIcon;
+        string result;
+        if (IsValid(currentAppIcon))
+        {
+            result = currentAppIcon;
+        }
+        else
+        {
+            // fallback to use default
+            result = Win32.AssocQueryString(assocFlag, Win32.AssocStr.DefaultIcon, extension);
+        }
+        return result;
+    }
+
+    private static bool IsValid(string icon)
+    {
+        if (string.IsNullOrEmpty(icon))
+            return false;
+        if (icon.TrimStart().StartsWith("%"))
+        {
+            // looks like because of invalid values in registry
+            return false;
+        }
+        return true;
     }
 }
 

--- a/src/Camelot.ViewModels.Windows/WinApi/ShellLinkResolver.cs
+++ b/src/Camelot.ViewModels.Windows/WinApi/ShellLinkResolver.cs
@@ -26,7 +26,7 @@ public class ShellLinkResolver : IShellLinkResolver
         }
 
         var ext = _pathService.GetExtension(path).ToLower();
-        if (ext != ".lnk")
+        if (ext != "lnk")
         {
             throw new ArgumentNullException(nameof(path));
         }


### PR DESCRIPTION
fixed shell icons, which didn't work because IPathService and System.IO.Path return different values for GetExtension