### PR TITLE
appearance - show keyboard hints

### DIFF
--- a/src/Camelot.Services.Abstractions/IAppearanceSettingsService.cs
+++ b/src/Camelot.Services.Abstractions/IAppearanceSettingsService.cs
@@ -1,0 +1,11 @@
+using Camelot.Services.Abstractions.Models;
+using Camelot.Services.Abstractions.Models.Enums;
+
+namespace Camelot.Services.Abstractions;
+
+public interface IAppearanceSettingsService
+{
+    AppearanceSettingsModel GetAppearanceSettings();
+
+    void SaveAppearanceSettings(AppearanceSettingsModel appearanceSettingsModel);
+}

--- a/src/Camelot.Services.Abstractions/IAppearanceSettingsService.cs
+++ b/src/Camelot.Services.Abstractions/IAppearanceSettingsService.cs
@@ -1,5 +1,4 @@
 using Camelot.Services.Abstractions.Models;
-using Camelot.Services.Abstractions.Models.Enums;
 
 namespace Camelot.Services.Abstractions;
 

--- a/src/Camelot.Services.Abstractions/Models/AppearanceSettingsModel.cs
+++ b/src/Camelot.Services.Abstractions/Models/AppearanceSettingsModel.cs
@@ -1,0 +1,11 @@
+namespace Camelot.Services.Abstractions.Models;
+
+public class AppearanceSettingsModel
+{
+    public bool ShowKeyboardShortcuts { get; }
+
+    public AppearanceSettingsModel(bool showKeyboardShortcuts)
+    {
+        ShowKeyboardShortcuts = showKeyboardShortcuts;
+    }
+}

--- a/src/Camelot.Services.Environment/Models/DriveInfo.cs
+++ b/src/Camelot.Services.Environment/Models/DriveInfo.cs
@@ -1,5 +1,4 @@
 using DriveType =  System.IO.DriveType;
-using IoDriveInfo = System.IO.DriveInfo;
 
 namespace Camelot.Services.Environment.Models;
 

--- a/src/Camelot.Services/AppearanceSettingsService.cs
+++ b/src/Camelot.Services/AppearanceSettingsService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Camelot.DataAccess.UnitOfWork;
+using Camelot.Services.Abstractions;
+using Camelot.Services.Abstractions.Models;
+using Camelot.Services.Abstractions.Models.Enums;
+
+namespace Camelot.Services;
+
+public class AppearanceSettingsService : IAppearanceSettingsService
+{
+    private const string SettingsId = "AppearanceSettings";
+    private readonly AppearanceSettingsModel _default;
+    private readonly IUnitOfWorkFactory _unitOfWorkFactory;
+    private AppearanceSettingsModel _cachedSettingsValue;
+    public AppearanceSettingsService(IUnitOfWorkFactory unitOfWorkFactory)
+    {
+        _unitOfWorkFactory = unitOfWorkFactory;
+        _default = new AppearanceSettingsModel(false);
+        GetAppearanceSettings();
+    }
+
+    public AppearanceSettingsModel GetAppearanceSettings()
+    {
+        if (_cachedSettingsValue == null)
+        {
+            using var uow = _unitOfWorkFactory.Create();
+            var repository = uow.GetRepository<AppearanceSettingsModel>();
+            var dbModel = repository.GetById(SettingsId);
+            if (dbModel != null)
+                _cachedSettingsValue = dbModel;
+            else
+                _cachedSettingsValue = _default;
+        }
+        else
+        {
+            // we set value of _cachedValue in 'save',
+            // so no need to read from the repository every time.
+        }
+        return _cachedSettingsValue;
+    }
+
+
+    public void SaveAppearanceSettings(AppearanceSettingsModel appearanceSettingsModel)
+    {
+        if (appearanceSettingsModel == null)
+            throw new ArgumentNullException(nameof(appearanceSettingsModel));
+
+        using var uow = _unitOfWorkFactory.Create();
+        var repository = uow.GetRepository<AppearanceSettingsModel>();
+        repository.Upsert(SettingsId, appearanceSettingsModel);
+        _cachedSettingsValue = appearanceSettingsModel;
+    }
+}

--- a/src/Camelot.Services/AppearanceSettingsService.cs
+++ b/src/Camelot.Services/AppearanceSettingsService.cs
@@ -1,19 +1,19 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Camelot.DataAccess.UnitOfWork;
 using Camelot.Services.Abstractions;
 using Camelot.Services.Abstractions.Models;
-using Camelot.Services.Abstractions.Models.Enums;
 
 namespace Camelot.Services;
 
 public class AppearanceSettingsService : IAppearanceSettingsService
 {
     private const string SettingsId = "AppearanceSettings";
+
     private readonly AppearanceSettingsModel _default;
     private readonly IUnitOfWorkFactory _unitOfWorkFactory;
+
     private AppearanceSettingsModel _cachedSettingsValue;
+
     public AppearanceSettingsService(IUnitOfWorkFactory unitOfWorkFactory)
     {
         _unitOfWorkFactory = unitOfWorkFactory;
@@ -28,16 +28,9 @@ public class AppearanceSettingsService : IAppearanceSettingsService
             using var uow = _unitOfWorkFactory.Create();
             var repository = uow.GetRepository<AppearanceSettingsModel>();
             var dbModel = repository.GetById(SettingsId);
-            if (dbModel != null)
-                _cachedSettingsValue = dbModel;
-            else
-                _cachedSettingsValue = _default;
+            _cachedSettingsValue = dbModel ?? _default;
         }
-        else
-        {
-            // we set value of _cachedValue in 'save',
-            // so no need to read from the repository every time.
-        }
+
         return _cachedSettingsValue;
     }
 
@@ -45,10 +38,13 @@ public class AppearanceSettingsService : IAppearanceSettingsService
     public void SaveAppearanceSettings(AppearanceSettingsModel appearanceSettingsModel)
     {
         if (appearanceSettingsModel == null)
+        {
             throw new ArgumentNullException(nameof(appearanceSettingsModel));
+        }
 
         using var uow = _unitOfWorkFactory.Create();
         var repository = uow.GetRepository<AppearanceSettingsModel>();
+
         repository.Upsert(SettingsId, appearanceSettingsModel);
         _cachedSettingsValue = appearanceSettingsModel;
     }

--- a/src/Camelot.ViewModels.Windows/ShellIcons/WindowsShellIconsService.cs
+++ b/src/Camelot.ViewModels.Windows/ShellIcons/WindowsShellIconsService.cs
@@ -3,7 +3,6 @@ using Camelot.ViewModels.Services.Interfaces;
 using Camelot.ViewModels.Services.Interfaces.Enums;
 using Camelot.ViewModels.Services.Interfaces.Models;
 using Camelot.ViewModels.Windows.WinApi;
-using SystemBitmap = System.Drawing.Bitmap;
 using AvaloniaBitmap = Avalonia.Media.Imaging.Bitmap;
 
 namespace Camelot.ViewModels.Windows.ShellIcons;

--- a/src/Camelot.ViewModels.Windows/WinApi/ShellIcon.cs
+++ b/src/Camelot.ViewModels.Windows/WinApi/ShellIcon.cs
@@ -1,5 +1,4 @@
 ﻿using Camelot.Services.Windows.WinApi;
-using System.Diagnostics;
 
 namespace Camelot.ViewModels.Windows.WinApi;
 

--- a/src/Camelot.ViewModels/Implementations/Dialogs/SettingsDialogViewModel.cs
+++ b/src/Camelot.ViewModels/Implementations/Dialogs/SettingsDialogViewModel.cs
@@ -17,6 +17,7 @@ public class SettingsDialogViewModel : DialogViewModelBase
     public ISettingsViewModel GeneralSettingsViewModel { get; set; }
     public ISettingsViewModel IconsSettingsViewModel { get; set; }
 
+    public ISettingsViewModel AppearanceSettingsViewModel { get; set; }
     public int SelectedIndex
     {
         get => _selectedIndex;
@@ -31,16 +32,21 @@ public class SettingsDialogViewModel : DialogViewModelBase
 
     public SettingsDialogViewModel(
         ISettingsViewModel generalSettingsViewModel,
+        ISettingsViewModel appearanceSettingsViewModel,
         ISettingsViewModel terminalSettingsViewModel,
         ISettingsViewModel iconsSettingsViewModel)
     {
         TerminalSettingsViewModel = terminalSettingsViewModel;
         GeneralSettingsViewModel = generalSettingsViewModel;
         IconsSettingsViewModel = iconsSettingsViewModel;
-
+        AppearanceSettingsViewModel = appearanceSettingsViewModel;
+        // Items in next array should be in same order as 'tabs' in xaml,
+        // Otherwise, Activate will called for wrong model.
+        // TODO: need to make it more dynamic, and not rely on order in view.
         _settingsViewModels = new[]
         {
             generalSettingsViewModel,
+            appearanceSettingsViewModel,
             terminalSettingsViewModel,
             iconsSettingsViewModel
         };

--- a/src/Camelot.ViewModels/Implementations/MainWindow/Operations/TopOperationsViewModel.cs
+++ b/src/Camelot.ViewModels/Implementations/MainWindow/Operations/TopOperationsViewModel.cs
@@ -22,6 +22,7 @@ public class TopOperationsViewModel : ViewModelBase, ITopOperationsViewModel
     private readonly IArchiveService _archiveService;
     private readonly INodesSelectionService _nodesSelectionService;
     private readonly ISystemDialogService _systemDialogService;
+    private readonly IAppearanceSettingsService _appearanceSettingsService;
 
     public ICommand PackCommand { get; }
 
@@ -31,6 +32,14 @@ public class TopOperationsViewModel : ViewModelBase, ITopOperationsViewModel
 
     public ICommand OpenTerminalCommand { get; }
 
+    public bool KeyboardShortcutIsVisible 
+    { 
+        get
+        {
+            return _appearanceSettingsService.GetAppearanceSettings().ShowKeyboardShortcuts;
+        }
+    }
+    
     public TopOperationsViewModel(
         ITerminalService terminalService,
         IDirectoryService directoryService,
@@ -39,7 +48,8 @@ public class TopOperationsViewModel : ViewModelBase, ITopOperationsViewModel
         IPathService pathService,
         IArchiveService archiveService,
         INodesSelectionService nodesSelectionService,
-        ISystemDialogService systemDialogService)
+        ISystemDialogService systemDialogService,
+        IAppearanceSettingsService appearanceSettingsService)
     {
         _terminalService = terminalService;
         _directoryService = directoryService;
@@ -49,6 +59,7 @@ public class TopOperationsViewModel : ViewModelBase, ITopOperationsViewModel
         _archiveService = archiveService;
         _nodesSelectionService = nodesSelectionService;
         _systemDialogService = systemDialogService;
+        _appearanceSettingsService = appearanceSettingsService;
 
         PackCommand = ReactiveCommand.CreateFromTask(PackAsync);
         ExtractCommand = ReactiveCommand.Create(ExtractAsync);

--- a/src/Camelot.ViewModels/Implementations/Settings/AppearanceSettingsViewModel.cs
+++ b/src/Camelot.ViewModels/Implementations/Settings/AppearanceSettingsViewModel.cs
@@ -17,7 +17,7 @@ public class AppearanceSettingsViewModel : ViewModelBase, ISettingsViewModel
 
 
     public bool IsChanged => _initialShowKeyboardShortcuts != ShowKeyboardShortcuts;
-    
+
     public AppearanceSettingsViewModel(
         IAppearanceSettingsService appearanceSettingService)
     {
@@ -34,13 +34,13 @@ public class AppearanceSettingsViewModel : ViewModelBase, ISettingsViewModel
         _isActivated = true;
 
         var model = _appearanceSettingService.GetAppearanceSettings();
-        _initialShowKeyboardShortcuts = model.ShowKeyboardShortcuts;
-        ShowKeyboardShortcuts = _initialShowKeyboardShortcuts;
+        ShowKeyboardShortcuts = _initialShowKeyboardShortcuts = model.ShowKeyboardShortcuts;
     }
 
     public void SaveChanges()
     {
         var model = new AppearanceSettingsModel(ShowKeyboardShortcuts);
+
         _appearanceSettingService.SaveAppearanceSettings(model);
     }
 }

--- a/src/Camelot.ViewModels/Implementations/Settings/AppearanceSettingsViewModel.cs
+++ b/src/Camelot.ViewModels/Implementations/Settings/AppearanceSettingsViewModel.cs
@@ -1,0 +1,46 @@
+﻿using Camelot.Services.Abstractions;
+using Camelot.Services.Abstractions.Models;
+using Camelot.ViewModels.Interfaces.Settings;
+using ReactiveUI.Fody.Helpers;
+
+namespace Camelot.ViewModels.Implementations.Settings;
+
+public class AppearanceSettingsViewModel : ViewModelBase, ISettingsViewModel
+{
+    private readonly IAppearanceSettingsService _appearanceSettingService;
+    private bool _initialShowKeyboardShortcuts;
+
+    private bool _isActivated;
+
+    [Reactive]
+    public bool ShowKeyboardShortcuts { get; set; }
+
+
+    public bool IsChanged => _initialShowKeyboardShortcuts != ShowKeyboardShortcuts;
+    
+    public AppearanceSettingsViewModel(
+        IAppearanceSettingsService appearanceSettingService)
+    {
+        _appearanceSettingService = appearanceSettingService;
+    }
+
+    public void Activate()
+    {
+        if (_isActivated)
+        {
+            return;
+        }
+
+        _isActivated = true;
+
+        var model = _appearanceSettingService.GetAppearanceSettings();
+        _initialShowKeyboardShortcuts = model.ShowKeyboardShortcuts;
+        ShowKeyboardShortcuts = _initialShowKeyboardShortcuts;
+    }
+
+    public void SaveChanges()
+    {
+        var model = new AppearanceSettingsModel(ShowKeyboardShortcuts);
+        _appearanceSettingService.SaveAppearanceSettings(model);
+    }
+}

--- a/src/Camelot/DependencyInjection/ServicesBootstrapper.cs
+++ b/src/Camelot/DependencyInjection/ServicesBootstrapper.cs
@@ -177,6 +177,10 @@ public static class ServicesBootstrapper
             resolver.GetRequiredService<IUnitOfWorkFactory>(),
             resolver.GetRequiredService<IPlatformService>()
         ));
+
+        services.RegisterLazySingleton<IAppearanceSettingsService>(() => new AppearanceSettingsService(
+           resolver.GetRequiredService<IUnitOfWorkFactory>()
+       ));
     }
 
     private static void RegisterPlatformSpecificServices(IMutableDependencyResolver services, IReadonlyDependencyResolver resolver)

--- a/src/Camelot/DependencyInjection/ViewModelsBootstrapper.cs
+++ b/src/Camelot/DependencyInjection/ViewModelsBootstrapper.cs
@@ -213,12 +213,17 @@ public static class ViewModelsBootstrapper
         ));
         services.Register(() => new SettingsDialogViewModel(
             resolver.GetRequiredService<GeneralSettingsViewModel>(),
+            resolver.GetRequiredService<AppearanceSettingsViewModel>(),
             resolver.GetRequiredService<TerminalSettingsViewModel>(),
             resolver.GetRequiredService<IconsSettingsViewModel>()
         ));
         services.Register(() => new IconsSettingsViewModel(
             resolver.GetRequiredService<IIconsSettingsService>()
         ));
+        services.Register(() => new AppearanceSettingsViewModel(
+            resolver.GetRequiredService<IAppearanceSettingsService>()
+        ));
+
         services.RegisterLazySingleton(() => new FilePropertiesBehavior(
             resolver.GetRequiredService<IDialogService>()
         ));
@@ -312,7 +317,8 @@ public static class ViewModelsBootstrapper
             resolver.GetRequiredService<IPathService>(),
             resolver.GetRequiredService<IArchiveService>(),
             resolver.GetRequiredService<INodesSelectionService>(),
-            resolver.GetRequiredService<ISystemDialogService>()
+            resolver.GetRequiredService<ISystemDialogService>(),
+            resolver.GetRequiredService<IAppearanceSettingsService>()
         ));
         services.RegisterLazySingleton<IOperationStateViewModelFactory>(() => new OperationStateViewModelFactory(
             resolver.GetRequiredService<IPathService>()

--- a/src/Camelot/Properties/Resources.Designer.cs
+++ b/src/Camelot/Properties/Resources.Designer.cs
@@ -914,5 +914,15 @@ namespace Camelot.Properties {
                 return ResourceManager.GetString("SupportedOnWindowsOnly", resourceCulture);
             }
         }
+   public static string Appearance {
+            get {
+                return ResourceManager.GetString("Appearance", resourceCulture);
+            }
+        }
+	public static string ShowKeyboardShortcuts {
+            get {
+                return ResourceManager.GetString("ShowKeyboardShortcuts", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Camelot/Properties/Resources.de.resx
+++ b/src/Camelot/Properties/Resources.de.resx
@@ -478,4 +478,7 @@
   <data name="FailedToPackFilesAndDirectoriesTo" xml:space="preserve">
     <value>Fehler beim Packen von {0} Dateien und {1} Verzeichnissen in {2}</value>
   </data>
+  <data name="Icons" xml:space="preserve">
+    <value>Symbole</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.es.resx
+++ b/src/Camelot/Properties/Resources.es.resx
@@ -481,4 +481,16 @@
   <data name="MarkAsFavourite" xml:space="preserve">
     <value>Marcar favorito</value>
   </data>
+  <data name="FilesIconsWithColon" xml:space="preserve">
+    <value>Archivo de iconos:</value>
+  </data>
+  <data name="SupportedOnWindowsOnly" xml:space="preserve">
+    <value>* Sólo compatible con Windows</value>
+  </data>
+  <data name="ChangesRequireRestart" xml:space="preserve">
+    <value>Los cambios requieren reiniciar la aplicación para que surtan efecto.</value>
+  </data>
+  <data name="Icons" xml:space="preserve">
+    <value>Iconos</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.hr.resx
+++ b/src/Camelot/Properties/Resources.hr.resx
@@ -481,4 +481,16 @@
   <data name="GoToParentDirectory" xml:space="preserve">
     <value>Idi u nadređenu mapu</value>
   </data>
+  <data name="FilesIconsWithColon" xml:space="preserve">
+    <value>Ikone datoteka:</value>
+  </data>
+  <data name="SupportedOnWindowsOnly" xml:space="preserve">
+    <value>* Podržano samo u Windows sustavu</value>
+  </data>
+  <data name="ChangesRequireRestart" xml:space="preserve">
+    <value>Program se mora ponovo pokrenuti kako bi promjene stupile na snagu.</value>
+  </data>
+  <data name="Icons" xml:space="preserve">
+    <value>Ikone</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.id.resx
+++ b/src/Camelot/Properties/Resources.id.resx
@@ -481,4 +481,16 @@
   <data name="InnerFilesWithColon" xml:space="preserve">
     <value>File dalam:</value>
   </data>
+  <data name="FilesIconsWithColon" xml:space="preserve">
+    <value>Ikon file:</value>
+  </data>
+  <data name="SupportedOnWindowsOnly" xml:space="preserve">
+    <value>* Didukung pada Windows hanya</value>
+  </data>
+  <data name="ChangesRequireRestart" xml:space="preserve">
+    <value>Perubahan memerlukan restart aplikasi untuk menerapkan efek.</value>
+  </data>
+  <data name="Icons" xml:space="preserve">
+    <value>Ikon</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.it.resx
+++ b/src/Camelot/Properties/Resources.it.resx
@@ -469,4 +469,22 @@
   <data name="MarkAsFavourite" xml:space="preserve">
     <value>Seleziona come preferito</value>
   </data>
+  <data name="FilesIconsWithColon" xml:space="preserve">
+    <value>Icone dei file:</value>
+  </data>
+  <data name="SupportedOnWindowsOnly" xml:space="preserve">
+    <value>* Supportato solo su Windows</value>
+  </data>
+  <data name="DuplicateOnOppositePanel" xml:space="preserve">
+    <value>Duplica sul pannello opposto</value>
+  </data>
+  <data name="PackingFileTo" xml:space="preserve">
+    <value>Il file {0} sta venendo compresso in {1}</value>
+  </data>
+  <data name="ChangesRequireRestart" xml:space="preserve">
+    <value>Le modifiche apportate richiedono il riavvio dell'applicazione per essere effettuate.</value>
+  </data>
+  <data name="Icons" xml:space="preserve">
+    <value>Icone</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.nb-NO.resx
+++ b/src/Camelot/Properties/Resources.nb-NO.resx
@@ -481,4 +481,16 @@
   <data name="GoToParentDirectory" xml:space="preserve">
     <value>Gå til inneholdende mappe</value>
   </data>
+  <data name="FilesIconsWithColon" xml:space="preserve">
+    <value>Filikoner:</value>
+  </data>
+  <data name="SupportedOnWindowsOnly" xml:space="preserve">
+    <value>* Støttes kun på Windows</value>
+  </data>
+  <data name="ChangesRequireRestart" xml:space="preserve">
+    <value>Endringer krever omstart av programmet for å ta effekt.</value>
+  </data>
+  <data name="Icons" xml:space="preserve">
+    <value>Ikoner</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.nl.resx
+++ b/src/Camelot/Properties/Resources.nl.resx
@@ -241,4 +241,112 @@
   <data name="FailedToMoveFileFromTo" xml:space="preserve">
     <value>Verplaatsen van {0} naar {1} is mislukt</value>
   </data>
+  <data name="Extract" xml:space="preserve">
+    <value>Extraheren</value>
+  </data>
+  <data name="ExtractingArchiveTo" xml:space="preserve">
+    <value>Etraheren van {0} naar {1}</value>
+  </data>
+  <data name="RemovingFileFromTo" xml:space="preserve">
+    <value>Verwijder {0} uit {1}</value>
+  </data>
+  <data name="ReplaceFileDestinationDirectory" xml:space="preserve">
+    <value>Er bestaat al een ander bestand met dezelfde naam in "{0}". Wil je het vervangen?</value>
+  </data>
+  <data name="PermanentlyRemoveFiles" xml:space="preserve">
+    <value>Wil je deze {0} bestanden permanent verwijderen?</value>
+  </data>
+  <data name="Size" xml:space="preserve">
+    <value>Grootte</value>
+  </data>
+  <data name="Skip" xml:space="preserve">
+    <value>Overslaan</value>
+  </data>
+  <data name="EnterFileNameWithColon" xml:space="preserve">
+    <value>Bestandsnaam invoeren:</value>
+  </data>
+  <data name="TotalSpaceWithColon" xml:space="preserve">
+    <value>Totale geheugenplaats:</value>
+  </data>
+  <data name="CreateFileTitle" xml:space="preserve">
+    <value>bestand aanmaken</value>
+  </data>
+  <data name="SizeWithColon" xml:space="preserve">
+    <value>Grootte:</value>
+  </data>
+  <data name="InvalidRegex" xml:space="preserve">
+    <value>Ongeldige regulaire uitdrukking</value>
+  </data>
+  <data name="Pack" xml:space="preserve">
+    <value>comprimeren</value>
+  </data>
+  <data name="MovedFileFromTo" xml:space="preserve">
+    <value>{0} naar {1} verplaatst</value>
+  </data>
+  <data name="File" xml:space="preserve">
+    <value>Bestand</value>
+  </data>
+  <data name="AvailableSpaceWithColon" xml:space="preserve">
+    <value>Beschikbare plaats:</value>
+  </data>
+  <data name="SearchForFilesAndDirectories" xml:space="preserve">
+    <value>Zoek naar bestanden en mappen</value>
+  </data>
+  <data name="FilesRemovingConfirmationTitle" xml:space="preserve">
+    <value>Bevestig verwijderen van bestanden</value>
+  </data>
+  <data name="MovingFileFromTo" xml:space="preserve">
+    <value>Verplaatsen van {0} naar {1}</value>
+  </data>
+  <data name="SettingsTitle" xml:space="preserve">
+    <value>Instellingen</value>
+  </data>
+  <data name="FileHeader" xml:space="preserve">
+    <value>_Bestand</value>
+  </data>
+  <data name="FailedToDeleteFilesAndDirectoriesFrom" xml:space="preserve">
+    <value>Verwijderen van {0} bestanden en {1} mappen van {2} mislukt</value>
+  </data>
+  <data name="SelectFromFilesAndDirectories" xml:space="preserve">
+    <value>{0} bestanden ({1}) en {2} mappen</value>
+  </data>
+  <data name="Search" xml:space="preserve">
+    <value>Zoeken</value>
+  </data>
+  <data name="MovedFilesFromAndDirectoriesTo" xml:space="preserve">
+    <value>{0} bestanden en {1} mappen naar {2} verplaatst</value>
+  </data>
+  <data name="MovingFromFilesAndDirectoriesTo" xml:space="preserve">
+    <value>Verplaats {0} bestanden en {1} mappen naar {2}</value>
+  </data>
+  <data name="SelectNewNameForDestination" xml:space="preserve">
+    <value>Kies een nieuwe naam voor de bestemming</value>
+  </data>
+  <data name="RemovingFilesAndDirectoriesFrom" xml:space="preserve">
+    <value>Verwijdert {0} bestanden en {1} mappen uit {2}</value>
+  </data>
+  <data name="RemovingFilesToTrash" xml:space="preserve">
+    <value>Wil je deze {0} bestanden verwijderen naar de prullenbak?</value>
+  </data>
+  <data name="ShowProperties" xml:space="preserve">
+    <value>Toon eigenschappen</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>_Instellingen</value>
+  </data>
+  <data name="FailedToMoveFilesAndDirectoriesTo" xml:space="preserve">
+    <value>Verplaatsen van {0} bestanden en {1} mappen naar {2} mislukt</value>
+  </data>
+  <data name="PackingFileTo" xml:space="preserve">
+    <value>Bestand {0} ingepakt op {1}</value>
+  </data>
+  <data name="PackingFilesAndDirectoriesTo" xml:space="preserve">
+    <value>{0} bestanden en {1} folders ingepakt naar {2}</value>
+  </data>
+  <data name="ExtractedArchiveTo" xml:space="preserve">
+    <value>Archief {0} uitgepakt op {1}</value>
+  </data>
+  <data name="PackedFileTo" xml:space="preserve">
+    <value>Bestand {0} ingepakt op {1}</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.pt.resx
+++ b/src/Camelot/Properties/Resources.pt.resx
@@ -481,4 +481,16 @@
   <data name="GoToParentDirectory" xml:space="preserve">
     <value>Ir para o diretório pai</value>
   </data>
+  <data name="FilesIconsWithColon" xml:space="preserve">
+    <value>Ficheiros de ícones:</value>
+  </data>
+  <data name="SupportedOnWindowsOnly" xml:space="preserve">
+    <value>* Apenas suportado em Windows</value>
+  </data>
+  <data name="ChangesRequireRestart" xml:space="preserve">
+    <value>Para que as alterações surtam efeito é necessário reiniciar a aplicação.</value>
+  </data>
+  <data name="Icons" xml:space="preserve">
+    <value>Ícones</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.resx
+++ b/src/Camelot/Properties/Resources.resx
@@ -552,4 +552,10 @@
   <data name="SupportedOnWindowsOnly" xml:space="preserve">
     <value>* Supported on Windows only</value>
   </data>
+  <data name="Appearance" xml:space="preserve">
+    <value>Appearance</value>
+  </data>
+  <data name="ShowKeyboardShortcuts" xml:space="preserve">
+    <value>Show keyboard shortcuts</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.sv.resx
+++ b/src/Camelot/Properties/Resources.sv.resx
@@ -424,4 +424,73 @@
   <data name="AboutCamelotTitle" xml:space="preserve">
     <value>Om Camelot</value>
   </data>
+  <data name="ApplyActionToTheAllFilesAndFolders" xml:space="preserve">
+    <value>Utför denna åtgärd på alla filer och mappar</value>
+  </data>
+  <data name="FilesIconsWithColon" xml:space="preserve">
+    <value>Fil ikoner:</value>
+  </data>
+  <data name="SupportedOnWindowsOnly" xml:space="preserve">
+    <value>* Stöds endast på Windows</value>
+  </data>
+  <data name="ReplaceIfOlder" xml:space="preserve">
+    <value>Byt ut om äldre</value>
+  </data>
+  <data name="AboutPage" xml:space="preserve">
+    <value>Camelot är filhanterare med dubbla paneler skriven i C#</value>
+  </data>
+  <data name="CaseSensitive" xml:space="preserve">
+    <value>Skiftlägeskänsliga</value>
+  </data>
+  <data name="InnerFilesWithColon" xml:space="preserve">
+    <value>Inre filer:</value>
+  </data>
+  <data name="CloseAllButThis" xml:space="preserve">
+    <value>Stäng alla utom denna</value>
+  </data>
+  <data name="Unmount" xml:space="preserve">
+    <value>Avmontera</value>
+  </data>
+  <data name="ClickToMount" xml:space="preserve">
+    <value>Klicka för att montera</value>
+  </data>
+  <data name="CreationDateWithColon" xml:space="preserve">
+    <value>Skapandedatum:</value>
+  </data>
+  <data name="OverwriteOptionsTitle" xml:space="preserve">
+    <value>Alternativ för överskrivning</value>
+  </data>
+  <data name="Maintainers" xml:space="preserve">
+    <value>Underhållare</value>
+  </data>
+  <data name="GoToParentDirectory" xml:space="preserve">
+    <value>Gå till överordnad katalog</value>
+  </data>
+  <data name="RegularExpression" xml:space="preserve">
+    <value>Vanligt uttryck</value>
+  </data>
+  <data name="Eject" xml:space="preserve">
+    <value>Mata ut</value>
+  </data>
+  <data name="PackToTheFileWithColon" xml:space="preserve">
+    <value>Packa till fil:</value>
+  </data>
+  <data name="InnerDirectoriesWithColon" xml:space="preserve">
+    <value>Inre kataloger:</value>
+  </data>
+  <data name="DuplicateOnOppositePanel" xml:space="preserve">
+    <value>Duplicera på motsatt panel</value>
+  </data>
+  <data name="SelectNewNameForDestination" xml:space="preserve">
+    <value>Välj ett nytt namn för destinationen</value>
+  </data>
+  <data name="RemovingFilesToTrash" xml:space="preserve">
+    <value>Vill du flytta dessa {0} filer till papperskorgen?</value>
+  </data>
+  <data name="ChangesRequireRestart" xml:space="preserve">
+    <value>Ändringar kräver omstart av programmet för att träda i kraft.</value>
+  </data>
+  <data name="Icons" xml:space="preserve">
+    <value>Ikoner</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.tr.resx
+++ b/src/Camelot/Properties/Resources.tr.resx
@@ -481,4 +481,16 @@
   <data name="GoToParentDirectory" xml:space="preserve">
     <value>Ana dizine git</value>
   </data>
+  <data name="FilesIconsWithColon" xml:space="preserve">
+    <value>Dosyalar simgeleri:</value>
+  </data>
+  <data name="SupportedOnWindowsOnly" xml:space="preserve">
+    <value>* Yalnızca Windows üstünden desteklenir</value>
+  </data>
+  <data name="ChangesRequireRestart" xml:space="preserve">
+    <value>Değişikliklerin etkili olabilmesi için uygulamanın yeniden başlatılmasını gerekir.</value>
+  </data>
+  <data name="Icons" xml:space="preserve">
+    <value>Simgeler</value>
+  </data>
 </root>

--- a/src/Camelot/Properties/Resources.zh-Hans.resx
+++ b/src/Camelot/Properties/Resources.zh-Hans.resx
@@ -481,4 +481,16 @@
   <data name="GoToParentDirectory" xml:space="preserve">
     <value>转到上一级目录</value>
   </data>
+  <data name="Icons" xml:space="preserve">
+    <value>图标</value>
+  </data>
+  <data name="ChangesRequireRestart" xml:space="preserve">
+    <value>需要重启应用来使改变生效。</value>
+  </data>
+  <data name="SupportedOnWindowsOnly" xml:space="preserve">
+    <value>* 仅支持 Windows 系统</value>
+  </data>
+  <data name="FilesIconsWithColon" xml:space="preserve">
+    <value>文件图标：</value>
+  </data>
 </root>

--- a/src/Camelot/Styles/MainWindow.xaml
+++ b/src/Camelot/Styles/MainWindow.xaml
@@ -35,6 +35,14 @@
         <Setter Property="Opacity" Value="0.5" />
         <Setter Property="Margin" Value="5,5,0,0" />
     </Style>
+    
+    <Style Selector="TextBlock.topOperationHotkeyTextBlock">
+        <Setter Property="FontFamily" Value="SansSerif" />
+        <Setter Property="Foreground" Value="{DynamicResource OperationButtonHotkeyBrush}" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Margin" Value="5,0,0,0" />
+    </Style>
 
     <Style Selector="Border.tabBorder">
         <Setter Property="CornerRadius" Value="4,4,0,0" />

--- a/src/Camelot/Views/Dialogs/Settings/AppearanceSettingsView.xaml
+++ b/src/Camelot/Views/Dialogs/Settings/AppearanceSettingsView.xaml
@@ -1,0 +1,38 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:p="clr-namespace:Camelot.Properties"
+             xmlns:settings="clr-namespace:Camelot.ViewModels.Implementations.Settings;assembly=Camelot.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Camelot.Views.Dialogs.Settings.AppearanceSettingsView"
+             x:DataType="settings:AppearanceSettingsViewModel"
+             x:CompileBindings="True">
+
+    <Design.DataContext>
+        <settings:AppearanceSettingsViewModel />
+    </Design.DataContext>
+    <Grid RowDefinitions="Auto,Auto,Auto"
+                        ColumnDefinitions="Auto"
+                        Margin="10">
+        <TextBlock 
+            Grid.Row="0"
+            Grid.Column="0"
+            Classes="settingsTabTextBlock" Margin="5,8,10,0"
+            Text="{x:Static p:Resources.ChangesRequireRestart}" />
+
+        <StackPanel Name="Quick Search"
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Margin="5,8,10,0"
+                    Orientation="Horizontal"
+                    Spacing="5">
+            <CheckBox 
+               IsChecked="{Binding ShowKeyboardShortcuts}">
+            </CheckBox>
+            <TextBlock
+                Classes="settingsTabTextBlock"
+                Text="{x:Static p:Resources.ShowKeyboardShortcuts}" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/Camelot/Views/Dialogs/Settings/AppearanceSettingsView.xaml.cs
+++ b/src/Camelot/Views/Dialogs/Settings/AppearanceSettingsView.xaml.cs
@@ -1,0 +1,13 @@
+﻿using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Camelot.Views.Dialogs.Settings;
+public class AppearanceSettingsView : UserControl
+{
+    public AppearanceSettingsView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+}

--- a/src/Camelot/Views/Dialogs/Settings/AppearanceSettingsView.xaml.cs
+++ b/src/Camelot/Views/Dialogs/Settings/AppearanceSettingsView.xaml.cs
@@ -2,6 +2,7 @@
 using Avalonia.Markup.Xaml;
 
 namespace Camelot.Views.Dialogs.Settings;
+
 public class AppearanceSettingsView : UserControl
 {
     public AppearanceSettingsView()

--- a/src/Camelot/Views/Dialogs/SettingsDialog.xaml
+++ b/src/Camelot/Views/Dialogs/SettingsDialog.xaml
@@ -17,7 +17,7 @@
     <Border Padding="10">
         <Grid RowDefinitions="*,Auto">
             <TabControl TabStripPlacement="Left" SelectedIndex="{Binding SelectedIndex}">
-                <TabItem VerticalContentAlignment="Center">
+                <TabItem Name="General" VerticalContentAlignment="Center">
                     <TabItem.Header>
                         <Border Classes="settingsTabHeaderBorder">
                             <StackPanel Orientation="Horizontal">
@@ -41,7 +41,33 @@
                         </Border>
                     </TabItem.Content>
                 </TabItem>
-                <TabItem VerticalContentAlignment="Center">
+                <TabItem Name="Appearance" VerticalContentAlignment="Center">
+                    <TabItem.Header>
+                        <Border Classes="settingsTabHeaderBorder">
+                            <StackPanel Orientation="Horizontal">
+                                <Image Width="20" Height="20" Margin="10,3,5,0">
+                                    <Image.Source>
+                                        <DrawingImage>
+                                            <DrawingImage.Drawing>
+                                                <GeometryDrawing Brush="{DynamicResource ThemeForegroundBrush}"
+                                                                 Geometry="M0 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6zm13 .25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5a.25.25 0 0 0-.25.25zM2.25 8a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 3 8.75v-.5A.25.25 0 0 0 2.75 8h-.5zM4 8.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 5 8.75v-.5A.25.25 0 0 0 4.75 8h-.5a.25.25 0 0 0-.25.25zM6.25 8a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 7 8.75v-.5A.25.25 0 0 0 6.75 8h-.5zM8 8.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 9 8.75v-.5A.25.25 0 0 0 8.75 8h-.5a.25.25 0 0 0-.25.25zM13.25 8a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5zm0 2a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5zm-3-2a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h1.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-1.5zm.75 2.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5a.25.25 0 0 0-.25.25zM11.25 6a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5zM9 6.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5A.25.25 0 0 0 9.75 6h-.5a.25.25 0 0 0-.25.25zM7.25 6a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 8 6.75v-.5A.25.25 0 0 0 7.75 6h-.5zM5 6.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 6 6.75v-.5A.25.25 0 0 0 5.75 6h-.5a.25.25 0 0 0-.25.25zM2.25 6a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h1.5A.25.25 0 0 0 4 6.75v-.5A.25.25 0 0 0 3.75 6h-1.5zM2 10.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5a.25.25 0 0 0-.25.25zM4.25 10a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h5.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-5.5z"/>
+                                            </DrawingImage.Drawing>
+                                        </DrawingImage>
+                                    </Image.Source>
+                                </Image>
+
+                                <TextBlock Classes="settingsTabTextBlock" Text="{x:Static p:Resources.Appearance}" />
+                            </StackPanel>
+                        </Border>
+                    </TabItem.Header>
+
+                    <TabItem.Content>
+                        <Border Classes="settingsContentBorder">
+                            <settings:AppearanceSettingsView DataContext="{Binding AppearanceSettingsViewModel}" />
+                        </Border>
+                    </TabItem.Content>
+                </TabItem>
+                <TabItem Name="Terminal" VerticalContentAlignment="Center">
                     <TabItem.Header>
                         <Border Classes="settingsTabHeaderBorder">
                             <StackPanel Orientation="Horizontal">
@@ -67,7 +93,7 @@
                         </Border>
                     </TabItem.Content>
                 </TabItem>
-                <TabItem VerticalContentAlignment="Center">
+                <TabItem Name="Icons" VerticalContentAlignment="Center">
                     <TabItem.Header>
                         <Border Classes="settingsTabHeaderBorder">
                             <StackPanel Orientation="Horizontal">

--- a/src/Camelot/Views/Dialogs/SettingsDialog.xaml
+++ b/src/Camelot/Views/Dialogs/SettingsDialog.xaml
@@ -49,8 +49,29 @@
                                     <Image.Source>
                                         <DrawingImage>
                                             <DrawingImage.Drawing>
-                                                <GeometryDrawing Brush="{DynamicResource ThemeForegroundBrush}"
-                                                                 Geometry="M0 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6zm13 .25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5a.25.25 0 0 0-.25.25zM2.25 8a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 3 8.75v-.5A.25.25 0 0 0 2.75 8h-.5zM4 8.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 5 8.75v-.5A.25.25 0 0 0 4.75 8h-.5a.25.25 0 0 0-.25.25zM6.25 8a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 7 8.75v-.5A.25.25 0 0 0 6.75 8h-.5zM8 8.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 9 8.75v-.5A.25.25 0 0 0 8.75 8h-.5a.25.25 0 0 0-.25.25zM13.25 8a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5zm0 2a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5zm-3-2a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h1.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-1.5zm.75 2.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5a.25.25 0 0 0-.25.25zM11.25 6a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5zM9 6.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5A.25.25 0 0 0 9.75 6h-.5a.25.25 0 0 0-.25.25zM7.25 6a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 8 6.75v-.5A.25.25 0 0 0 7.75 6h-.5zM5 6.25v.5c0 .138.112.25.25.25h.5A.25.25 0 0 0 6 6.75v-.5A.25.25 0 0 0 5.75 6h-.5a.25.25 0 0 0-.25.25zM2.25 6a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h1.5A.25.25 0 0 0 4 6.75v-.5A.25.25 0 0 0 3.75 6h-1.5zM2 10.25v.5c0 .138.112.25.25.25h.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-.5a.25.25 0 0 0-.25.25zM4.25 10a.25.25 0 0 0-.25.25v.5c0 .138.112.25.25.25h5.5a.25.25 0 0 0 .25-.25v-.5a.25.25 0 0 0-.25-.25h-5.5z"/>
+                                                <DrawingGroup ClipGeometry="M0,0 V24 H24 V0 H0 Z">
+                                                    <GeometryDrawing Brush="{DynamicResource ThemeForegroundBrush}" Geometry="F1 M24,24z M0,0z M13.4,2.096A10.08,10.08,0,0,0,4.463,5.427A10.054,10.054,0,0,0,2.096,13.4C2.626,17.294,5.554,20.607,9.381,21.646A9.982,9.982,0,0,0,11.999,22L12.141,21.999A3.001,3.001,0,0,0,14.657,20.573A2.989,2.989,0,0,0,14.81,17.694L14.611,17.278A1.919,1.919,0,0,1,14.705,15.366A2.004,2.004,0,0,1,17.281,14.611L17.693,14.808C18.105,15.006,18.543,15.107,18.994,15.107A3.022,3.022,0,0,0,22,12.14A9.935,9.935,0,0,0,21.647,9.38C20.607,5.554,17.294,2.626,13.4,2.096z M18.558,13.005L18.146,12.808C16.318,11.93 14.076,12.61 13.011,14.302 12.273,15.478 12.198,16.878 12.807,18.144L13.006,18.56A0.983,0.983,0,0,1,12.955,19.521A0.992,0.992,0,0,1,12.111,20L11.999,20A8.061,8.061,0,0,1,9.904,19.717C6.841,18.886 4.501,16.238 4.078,13.131 3.757,10.776 4.43,8.508 5.971,6.742A8.002,8.002,0,0,1,13.131,4.078C16.238,4.501 18.886,6.842 19.717,9.904 19.915,10.634 20.01,11.378 19.999,12.111 19.987,12.918 19.154,13.294 18.558,13.005z" />
+                                                    <GeometryDrawing Brush="{DynamicResource ThemeForegroundBrush}">
+                                                        <GeometryDrawing.Geometry>
+                                                            <EllipseGeometry RadiusX="1.5" RadiusY="1.5" Center="7.5,14.5" />
+                                                        </GeometryDrawing.Geometry>
+                                                    </GeometryDrawing>
+                                                    <GeometryDrawing Brush="{DynamicResource ThemeForegroundBrush}">
+                                                        <GeometryDrawing.Geometry>
+                                                            <EllipseGeometry RadiusX="1.5" RadiusY="1.5" Center="7.5,10.5" />
+                                                        </GeometryDrawing.Geometry>
+                                                    </GeometryDrawing>
+                                                    <GeometryDrawing Brush="{DynamicResource ThemeForegroundBrush}">
+                                                        <GeometryDrawing.Geometry>
+                                                            <EllipseGeometry RadiusX="1.5" RadiusY="1.5" Center="10.5,7.5" />
+                                                        </GeometryDrawing.Geometry>
+                                                    </GeometryDrawing>
+                                                    <GeometryDrawing Brush="{DynamicResource ThemeForegroundBrush}">
+                                                        <GeometryDrawing.Geometry>
+                                                            <EllipseGeometry RadiusX="1.5" RadiusY="1.5" Center="14.5,7.5" />
+                                                        </GeometryDrawing.Geometry>
+                                                    </GeometryDrawing>
+                                                </DrawingGroup>
                                             </DrawingImage.Drawing>
                                         </DrawingImage>
                                     </Image.Source>

--- a/src/Camelot/Views/Main/TopOperationsView.xaml
+++ b/src/Camelot/Views/Main/TopOperationsView.xaml
@@ -27,6 +27,7 @@
                 </Image>
 
                 <TextBlock Text="{x:Static p:Resources.Search}" />
+                <TextBlock IsVisible="{Binding KeyboardShortcutIsVisible}" Classes="topOperationHotkeyTextBlock" Text="[^F]" />
             </StackPanel>
         </Button>
 
@@ -45,6 +46,7 @@
                 </Image>
 
                 <TextBlock Text="{x:Static p:Resources.Terminal}" />
+                <TextBlock IsVisible="{Binding KeyboardShortcutIsVisible}" Classes="topOperationHotkeyTextBlock" Text="[F9]" />
             </StackPanel>
         </Button>
 
@@ -63,6 +65,7 @@
                 </Image>
 
                 <TextBlock Text="{x:Static p:Resources.Pack}" />
+                <TextBlock IsVisible="{Binding KeyboardShortcutIsVisible}" Classes="topOperationHotkeyTextBlock" Text="[F10]" />
             </StackPanel>
         </Button>
 
@@ -81,6 +84,7 @@
                 </Image>
 
                 <TextBlock Text="{x:Static p:Resources.Extract}" />
+                <TextBlock IsVisible="{Binding KeyboardShortcutIsVisible}" Classes="topOperationHotkeyTextBlock" Text="[F11]" />
             </StackPanel>
         </Button>
     </StackPanel>

--- a/tests/Camelot.ViewModels.Tests/Dialogs/SettingsDialogViewModelTests.cs
+++ b/tests/Camelot.ViewModels.Tests/Dialogs/SettingsDialogViewModelTests.cs
@@ -25,7 +25,12 @@ public class SettingsDialogViewModelTests
             .Setup(m => m.Activate())
             .Verifiable();
 
+        var appearanceSettingsViewModel = new Mock<ISettingsViewModel>();
+             appearanceSettingsViewModel
+            .Setup(m => m.Activate())
+            .Verifiable();
         var dialogViewModel = new SettingsDialogViewModel(generalSettingsViewModel.Object,
+            appearanceSettingsViewModel.Object,
             terminalSettingsViewModel.Object,
             iconsSettingsViewModel.Object);
 
@@ -64,8 +69,13 @@ public class SettingsDialogViewModelTests
             .SetupGet(m => m.IsChanged)
             .Returns(true);
 
+    var appearanceSettingsViewModel = new Mock<ISettingsViewModel>();
+        appearanceSettingsViewModel
+            .Setup(m => m.Activate())
+            .Verifiable();
         var dialogViewModel = new SettingsDialogViewModel(
             generalSettingsViewModel.Object,
+            appearanceSettingsViewModel.Object,
             terminalSettingsViewModel.Object,
             iconsSettingsViewModel.Object);
 
@@ -95,8 +105,13 @@ public class SettingsDialogViewModelTests
             .Setup(m => m.Activate())
             .Verifiable();
 
+      var appearanceSettingsViewModel = new Mock<ISettingsViewModel>();
+        appearanceSettingsViewModel
+            .Setup(m => m.Activate())
+            .Verifiable();
         var dialogViewModel = new SettingsDialogViewModel(
             generalSettingsViewModel.Object, 
+            appearanceSettingsViewModel.Object,
             terminalSettingsViewModel.Object,
             iconsSettingsViewModel.Object);
 
@@ -126,8 +141,13 @@ public class SettingsDialogViewModelTests
             .Setup(m => m.Activate())
             .Verifiable();
 
+       var appearanceSettingsViewModel = new Mock<ISettingsViewModel>();
+        appearanceSettingsViewModel
+            .Setup(m => m.Activate())
+            .Verifiable();
         var dialogViewModel = new SettingsDialogViewModel(
             generalSettingsViewModel.Object, 
+            appearanceSettingsViewModel.Object,
             terminalSettingsViewModel.Object, 
             iconsSettingsViewModel.Object)
         {


### PR DESCRIPTION
**Motivation**
Improve usability by showing user keyboard shortcuts on screen

**Scope**
Added new tab called "Appearance" under settings.
(Name and icon were selected to be same as in Google chrome).
The new tab has a checkbox to control whether keyboard hints should be visible in top bar.
For backwards compatibility, the checkbox controls visibility of hints only on top bar, not on bottom (eg F4, F5, etc)
See attached image.
(Future feature in settings is to move also "Theme" from "General" to "Appearance", same as in Google Chrome)

![image](https://github.com/IngvarX/Camelot/assets/65832579/550979d5-8dba-407c-a656-a7619757305a)
